### PR TITLE
Added the ability to apply most ModSwap-compatible mods

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "cSpell.words": ["klaw", "immer"],
+    "cSpell.words": ["gamefile", "immer", "klaw"],
     "terminal.integrated.defaultProfile.windows": "Git Bash",
     "terminal.integrated.profiles.windows": {
         "PowerShell": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -634,7 +634,11 @@ export const App: FC = (): React.ReactElement => {
                                                                 mod
                                                             );
                                                         }
-                                                        loadModFileNames();
+                                                        await loadModFileNames();
+                                                        // Clear checked mods after deletion
+                                                        dispatch({
+                                                            type: 'CLEAR_CHECKED_MODS',
+                                                        });
                                                     }}
                                                 >
                                                     <TrashIcon />

--- a/src/app-reducer.ts
+++ b/src/app-reducer.ts
@@ -27,7 +27,8 @@ export type AppAction =
     | { payload: string; type: 'TOGGLE_CHECKED_MOD' }
     | { payload: string[]; type: 'SET_MOD_NAMES_QUEUED' }
     | { payload: string[] | undefined; type: 'SET_MOD_NAMES_ADDED' }
-    | { payload: string | undefined; type: 'SET_ERROR' };
+    | { payload: string | undefined; type: 'SET_ERROR' }
+    | { type: 'CLEAR_CHECKED_MODS' }; // Add new action type without payload
 
 // Define state interface
 export interface AppState {
@@ -86,6 +87,9 @@ export const appReducer = (
     switch (action.type) {
         case 'ADD_TO_INSTALL_DIRS':
             draft.installDirs.push(...action.payload);
+            break;
+        case 'CLEAR_CHECKED_MODS':
+            draft.checkedMods = [];
             break;
         case 'DEQUEUE_MOD':
             if (draft.modNamesAdded) {

--- a/src/electron/file/getGamefileFiles.ts
+++ b/src/electron/file/getGamefileFiles.ts
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * A gamefile refers to any file in a mod ending in 'gamefile.txt'. These files are used in the Modswapper program
+ * to apply various mods and contain information about the mod being applied. They are NOT referring to game asset files.
+ */
+
+type GamefileInfo = {
+    contents: string;
+    fileName: string;
+};
+
+/**
+ * Retrieves an array of game file information objects from a specified directory.
+ *
+ * This function scans the provided directory for files that end with 'gamefile.txt',
+ * reads their contents, and returns an array of objects containing the file contents
+ * and file names.
+ * @param dir - The directory to search for game files.
+ * @returns An array of `GamefileInfo` objects, each containing the contents and name
+ *          of a game file.
+ * @throws Logs an error to the console if the directory cannot be read or if any
+ *         file operations fail.
+ */
+export const getGamefileFiles = (dir: string): GamefileInfo[] => {
+    const result: GamefileInfo[] = [];
+
+    try {
+        const files = fs.readdirSync(dir);
+
+        for (const file of files) {
+            const filePath = path.join(dir, file);
+
+            if (
+                fs.statSync(filePath).isFile() &&
+                file.endsWith('gamefile.txt')
+            ) {
+                const contents = fs.readFileSync(filePath, 'utf-8');
+                result.push({ contents, fileName: file });
+            }
+        }
+    } catch (err) {
+        console.error(`Error reading directory ${dir}:`, err);
+    }
+
+    return result;
+};

--- a/src/electron/file/getGamefileFiles.ts
+++ b/src/electron/file/getGamefileFiles.ts
@@ -9,39 +9,57 @@ import path from 'path';
 type GamefileInfo = {
     contents: string;
     fileName: string;
+    path: string;
 };
 
 /**
- * Retrieves an array of game file information objects from a specified directory.
+ * Retrieves an array of game file information objects from a specified directory and all its subdirectories.
  *
- * This function scans the provided directory for files that end with 'gamefile.txt',
- * reads their contents, and returns an array of objects containing the file contents
- * and file names.
+ * This function iteratively scans the provided directory and all its subdirectories for files that
+ * end with 'gamefile.txt', reads their contents, and returns an array of objects containing
+ * the file contents and file names.
  * @param dir - The directory to search for game files.
  * @returns An array of `GamefileInfo` objects, each containing the contents and name
  *          of a game file.
- * @throws Logs an error to the console if the directory cannot be read or if any
+ * @throws Logs an error to the console if directories cannot be read or if any
  *         file operations fail.
  */
 export const getGamefileFiles = (dir: string): GamefileInfo[] => {
     const result: GamefileInfo[] = [];
+    const directories: string[] = [dir];
 
-    try {
-        const files = fs.readdirSync(dir);
+    while (directories.length > 0) {
+        const currentDir = directories.pop();
 
-        for (const file of files) {
-            const filePath = path.join(dir, file);
+        try {
+            const items = fs.readdirSync(currentDir);
 
-            if (
-                fs.statSync(filePath).isFile() &&
-                file.endsWith('gamefile.txt')
-            ) {
-                const contents = fs.readFileSync(filePath, 'utf-8');
-                result.push({ contents, fileName: file });
+            for (const item of items) {
+                const itemPath = path.join(currentDir, item);
+
+                try {
+                    const stats = fs.statSync(itemPath);
+
+                    if (stats.isDirectory()) {
+                        directories.push(itemPath);
+                    } else if (
+                        stats.isFile() &&
+                        item.endsWith('gamefile.txt')
+                    ) {
+                        const contents = fs.readFileSync(itemPath, 'utf-8');
+                        result.push({
+                            contents,
+                            fileName: item,
+                            path: itemPath,
+                        });
+                    }
+                } catch (err) {
+                    console.error(`Error processing path ${itemPath}:`, err);
+                }
             }
+        } catch (err) {
+            console.error(`Error reading directory ${currentDir}:`, err);
         }
-    } catch (err) {
-        console.error(`Error reading directory ${dir}:`, err);
     }
 
     return result;

--- a/src/electron/file/parseGamefileContent.ts
+++ b/src/electron/file/parseGamefileContent.ts
@@ -1,0 +1,30 @@
+/**
+ * A gamefile refers to any file in a mod ending in 'gamefile.txt'. These files are used in the Modswapper program
+ * to apply various mods and contain information about the mod being applied. They are NOT referring to game asset files.
+ */
+
+/**
+ * Extracts specific mod information from gamefile content by reading specific lines.
+ * These lines contain information about the mod files that need to be swapped by Modswapper.
+ * @param content - The content of a gamefile.txt file as a string
+ * @returns An object containing extracted mod information from specified lines
+ */
+export const parseGamefileContent = (
+    content: string
+): {
+    greatLibraryName: null | string;
+    ldlStrName: null | string;
+    modName: null | string;
+    newspriteName: null | string;
+    tipsStrName: null | string;
+} => {
+    const lines = content.split('\n');
+
+    return {
+        greatLibraryName: lines.length >= 68 ? lines[67].trim() : null,
+        ldlStrName: lines.length >= 70 ? lines[69].trim() : null,
+        modName: lines.length >= 66 ? lines[65].trim() : null,
+        newspriteName: lines.length >= 67 ? lines[66].trim() : null,
+        tipsStrName: lines.length >= 69 ? lines[68].trim() : null,
+    };
+};

--- a/src/electron/file/parseGamefileContent.ts
+++ b/src/electron/file/parseGamefileContent.ts
@@ -21,10 +21,10 @@ export const parseGamefileContent = (
     const lines = content.split('\n');
 
     return {
-        greatLibraryName: lines.length >= 68 ? lines[67].trim() : null,
-        ldlStrName: lines.length >= 70 ? lines[69].trim() : null,
-        modName: lines.length >= 66 ? lines[65].trim() : null,
-        newspriteName: lines.length >= 67 ? lines[66].trim() : null,
-        tipsStrName: lines.length >= 69 ? lines[68].trim() : null,
+        greatLibraryName: lines.length >= 68 ? lines[67].trim() : null, // corresponds to GreatLibrary.txt
+        ldlStrName: lines.length >= 70 ? lines[69].trim() : null, // corresponds to ldl_str.txt
+        modName: lines.length >= 66 ? lines[65].trim() : null, // name of the mod, shows up in ModSwap like this
+        newspriteName: lines.length >= 67 ? lines[66].trim() : null, // corresponds to newsprite.txt
+        tipsStrName: lines.length >= 69 ? lines[68].trim() : null, // corresponds to tips_str.txt
     };
 };

--- a/src/electron/file/parseGamefileContent.ts
+++ b/src/electron/file/parseGamefileContent.ts
@@ -7,11 +7,14 @@
  * Extracts specific mod information from gamefile content by reading specific lines.
  * These lines contain information about the mod files that need to be swapped by Modswapper.
  * @param content - The content of a gamefile.txt file as a string
+ * @param gamefilePath - The path to the gamefile for resolving relative paths
  * @returns An object containing extracted mod information from specified lines
  */
 export const parseGamefileContent = (
-    content: string
+    content: string,
+    gamefilePath?: string
 ): {
+    gamefilePath?: string;
     greatLibraryName: null | string;
     ldlStrName: null | string;
     modName: null | string;
@@ -21,7 +24,8 @@ export const parseGamefileContent = (
     const lines = content.split('\n');
 
     return {
-        greatLibraryName: lines.length >= 68 ? lines[67].trim() : null, // corresponds to GreatLibrary.txt
+        gamefilePath,
+        greatLibraryName: lines.length >= 68 ? lines[67].trim() : null, // corresponds to Great_Library.txt
         ldlStrName: lines.length >= 70 ? lines[69].trim() : null, // corresponds to ldl_str.txt
         modName: lines.length >= 66 ? lines[65].trim() : null, // name of the mod, shows up in ModSwap like this
         newspriteName: lines.length >= 67 ? lines[66].trim() : null, // corresponds to newsprite.txt

--- a/src/electron/file/processGamefileMods.ts
+++ b/src/electron/file/processGamefileMods.ts
@@ -27,6 +27,10 @@ const createFileMappings = (
         { destination: 'ldl_str.txt', source: gamefileInfo.ldlStrName },
         { destination: 'newsprite.txt', source: gamefileInfo.newspriteName },
         { destination: 'tips_str.txt', source: gamefileInfo.tipsStrName },
+        {
+            destination: 'gamefile.txt',
+            source: path.basename(gamefileInfo.gamefilePath),
+        },
     ].filter((mapping) => mapping.source !== null) as GamefileMapping[];
 };
 

--- a/src/electron/file/processGamefileMods.ts
+++ b/src/electron/file/processGamefileMods.ts
@@ -1,0 +1,203 @@
+import fs from 'fs';
+import path from 'path';
+import { ReadonlyDeep } from 'type-fest';
+
+import { DEFAULT_MOD_DIR } from '../constants';
+import { getGamefileFiles } from './getGamefileFiles';
+import { parseGamefileContent } from './parseGamefileContent';
+
+interface GamefileMapping {
+    destination: string;
+    source: null | string;
+}
+
+/**
+ * Maps the gamefile content fields to their destination file names
+ * @param gamefileInfo Parsed information from the gamefile
+ * @returns An array of mapping objects for source and destination files
+ */
+const createFileMappings = (
+    gamefileInfo: ReadonlyDeep<ReturnType<typeof parseGamefileContent>>
+): GamefileMapping[] => {
+    return [
+        {
+            destination: 'Great_Library.txt',
+            source: gamefileInfo.greatLibraryName,
+        },
+        { destination: 'ldl_str.txt', source: gamefileInfo.ldlStrName },
+        { destination: 'newsprite.txt', source: gamefileInfo.newspriteName },
+        { destination: 'tips_str.txt', source: gamefileInfo.tipsStrName },
+    ].filter((mapping) => mapping.source !== null) as GamefileMapping[];
+};
+
+/**
+ * Finds a file in the mod directory based on its filename
+ * @param modDir The root directory of the mod
+ * @param filename The filename to search for
+ * @returns The full path to the file if found, null otherwise
+ */
+const findFileInMod = (
+    modDir: string,
+    filename: null | string
+): null | string => {
+    if (!filename) return null;
+
+    // Use a stack to traverse directories without recursion
+    const directories: string[] = [modDir];
+    while (directories.length > 0) {
+        const currentDir = directories.pop()!;
+
+        try {
+            const items = fs.readdirSync(currentDir);
+
+            for (const item of items) {
+                const itemPath = path.join(currentDir, item);
+                const stats = fs.statSync(itemPath);
+
+                if (stats.isDirectory()) {
+                    directories.push(itemPath);
+                } else if (item === filename) {
+                    return itemPath;
+                }
+            }
+        } catch (err) {
+            console.error(`Error reading directory ${currentDir}:`, err);
+        }
+    }
+
+    return null;
+};
+/**
+ * Copies files from source directory to destination directory, preserving structure
+ * @param srcDir The source directory (also used as reference for calculating relative paths)
+ * @param destDir The destination directory
+ * @param filesToSkip Files that should be skipped during copying (e.g. files to be renamed)
+ */
+const copyRemainingFiles = (
+    srcDir: string,
+    destDir: string,
+    filesToSkip: ReadonlyDeep<string[]>
+): void => {
+    // Calculate relative path from srcDir to itself (empty string)
+    // This simplifies the initial call but allows recursion to work with subdirectories
+    const relativePath = path.relative(srcDir, srcDir);
+    const targetDir = path.join(destDir, relativePath);
+
+    // Create the target directory if it doesn't exist
+    fs.mkdirSync(targetDir, { recursive: true });
+
+    // Process each item in the current directory
+    const items = fs.readdirSync(srcDir);
+    for (const item of items) {
+        const srcPath = path.join(srcDir, item);
+        const stats = fs.statSync(srcPath);
+
+        if (stats.isDirectory()) {
+            // Recursively process subdirectories
+            // For subdirectories, we need to calculate proper relative path
+            const subRelPath = path.relative(srcDir, srcPath);
+            const subDestDir = path.join(destDir, subRelPath);
+            fs.mkdirSync(subDestDir, { recursive: true });
+            copyRemainingFiles(srcPath, subDestDir, filesToSkip);
+        } else {
+            // Skip files that are already handled by specific mappings
+            if (filesToSkip.includes(path.basename(srcPath))) {
+                continue;
+            }
+
+            // Copy the file to the target directory, preserving the name
+            const destPath = path.join(targetDir, item);
+            fs.copyFileSync(srcPath, destPath);
+        }
+    }
+};
+
+/**
+ * Processes a mod directory for gamefiles and creates separate mod folders with renamed files
+ * @param modDir The directory containing the mod
+ * @returns An array of new mod folder names created
+ */
+export const processGamefileMods = (modDir: string): string[] => {
+    const createdMods: string[] = [];
+
+    try {
+        // Find all gamefile.txt files in the mod directory
+        const gamefiles = getGamefileFiles(modDir);
+
+        if (gamefiles.length === 0) {
+            console.log('No gamefile found in the mod directory');
+            return createdMods;
+        }
+
+        // Process each gamefile
+        for (const gamefile of gamefiles) {
+            const gamefileInfo = parseGamefileContent(
+                gamefile.contents,
+                gamefile.path
+            );
+
+            if (!gamefileInfo.modName) {
+                console.error('No mod name found in gamefile:', gamefile.path);
+                continue;
+            }
+
+            // Create a new mod folder with the name from the gamefile
+            const newModDir = path.join(DEFAULT_MOD_DIR, gamefileInfo.modName);
+
+            // Check if the mod directory already exists
+            if (fs.existsSync(newModDir)) {
+                console.log(`Mod directory already exists: ${newModDir}`);
+            } else {
+                fs.mkdirSync(newModDir, { recursive: true });
+            }
+
+            // Get file mappings from gamefile info
+            const fileMappings = createFileMappings(gamefileInfo);
+
+            // Get list of source files to skip during copying
+            const filesToSkip = fileMappings
+                .map((mapping) => mapping.source)
+                .filter((source): source is string => source !== null);
+
+            // Copy all mod files to the new directory, maintaining the folder structure
+            copyRemainingFiles(modDir, newModDir, filesToSkip);
+
+            // Copy each mapped file to the new mod directory with the correct name
+            for (const mapping of fileMappings) {
+                const sourceFilePath = findFileInMod(modDir, mapping.source);
+
+                if (sourceFilePath) {
+                    // Get the relative path from the mod root to the source file
+                    const relativePath = path.relative(
+                        modDir,
+                        path.dirname(sourceFilePath)
+                    );
+
+                    // Create the same directory structure in the new mod folder
+                    const destDir = path.join(newModDir, relativePath);
+                    fs.mkdirSync(destDir, { recursive: true });
+
+                    // Copy the file with its new name
+                    const destPath = path.join(destDir, mapping.destination);
+                    fs.copyFileSync(sourceFilePath, destPath);
+
+                    console.log(`Copied ${sourceFilePath} to ${destPath}`);
+                } else {
+                    console.warn(
+                        `Source file not found for source ${mapping.source}. Full mapping: ${JSON.stringify(
+                            mapping,
+                            null,
+                            2
+                        )}`
+                    );
+                }
+            }
+
+            createdMods.push(gamefileInfo.modName);
+        }
+    } catch (err) {
+        console.error('Error processing gamefiles:', err);
+    }
+
+    return createdMods;
+};

--- a/src/electron/file/processGamefileMods.ts
+++ b/src/electron/file/processGamefileMods.ts
@@ -49,7 +49,7 @@ const findFileInMod = (
     // Use a stack to traverse directories without recursion
     const directories: string[] = [modDir];
     while (directories.length > 0) {
-        const currentDir = directories.pop()!;
+        const currentDir = directories.pop();
 
         try {
             const items = fs.readdirSync(currentDir);


### PR DESCRIPTION
The mod manager will now respect all `gamefile.txt` present in the mods. The following mods now apply successfully: 

- Super Apolyton Pack
- GoodMod for Super Apolyton Pack (other versions of GoodMod, such as the one for CityMod2, are untested)
- Lord of the Rings (all 3 versions)
- World at War!

The following mods have been tested and still have issues:
- Ages of Man (appears to be a bug with the way that the mod manager unpacks nested folders - could probably be fixed with some better organization. The game launches but crashes with errors)
- VisibleWonders (it might work, it shows the dialogue box when a wonder was made, but the wonder does not appear to be next to the city as far as I can tell)